### PR TITLE
Fix menu-content overlap.

### DIFF
--- a/css/theme.css
+++ b/css/theme.css
@@ -17991,8 +17991,6 @@ main {
       .navigation:not(.fixed-top) {
         position: static;
         top: -90px; }
-      .navigation.fixed-top {
-        background-color: transparent; }
         .navigation.fixed-top .navbar-collapse {
           height: auto; }
         .navigation.fixed-top .nav-link {


### PR DESCRIPTION
Removes transparency from the top menu on larger screens so that content no longer meshes with the menu, particularly on the rules page.